### PR TITLE
Fix README in pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="sanpy",
-    version="0.0.9",
+    version="0.0.12",
     author="Santiment",
     author_email="admin@santiment.net",
     description="Package for Santiment API access with python",


### PR DESCRIPTION
The problem is that when you're generating the distribution archive you
need to meet the following package version in order to generate proper
documentation:

* Make sure setuptools is upgraded to version 38.6.0 or newer
* Make sure twine is upgraded to version 1.11.0 or newer
* Make sure wheel is upgraded to version 0.31.0 or newer

See this answer in stackoverflow: https://stackoverflow.com/a/26737258