### PR TITLE
Fix batching sorting

### DIFF
--- a/san/batch.py
+++ b/san/batch.py
@@ -20,8 +20,10 @@ class Batch:
         gql_string = self.__batch_gql_queries(batched_queries)
         res = execute_gql(gql_string)
 
-        for k in sorted(res.keys()):
-            df = convert_to_datetime_idx_df(res[k])
+        idxs = sorted([int(k.split('_')[1]) for k in res.keys()])
+        for idx in idxs:
+            key = "query_{}".format(idx)
+            df = convert_to_datetime_idx_df(res[key])
             result.append(df)
 
         return result

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="sanpy",
-    version="0.0.19",
+    version="0.0.20",
     author="Santiment",
     author_email="admin@santiment.net",
     description="Package for Santiment API access with python",


### PR DESCRIPTION
batching doesn't return queries in the order they are batched. Thats due to that we are sorting string - 
so `query_10` goes before `query_2`