### PR TITLE
Improve the error handling when exectuing graphql

### DIFF
--- a/san/graphql.py
+++ b/san/graphql.py
@@ -5,40 +5,45 @@ from san.error import SanError
 
 
 def execute_gql(gql_query_str):
-    headers = {}
-    if ApiConfig.api_key:
-        headers = {'authorization': "Apikey {}".format(ApiConfig.api_key)}
+  headers = {}
+  if ApiConfig.api_key:
+    headers = {'authorization': "Apikey {}".format(ApiConfig.api_key)}
 
-    response = requests.post(
-        SANBASE_GQL_HOST,
-        json={
-            'query': gql_query_str},
-        headers=headers)
+  response = requests.post(
+    SANBASE_GQL_HOST,
+    json={
+        'query': gql_query_str},
+    headers=headers)
 
-    if response.status_code == 200:
-        if __exist_not_empty_result(response):
-            return response.json()['data']
-        else:
-            raise SanError(
-                "Error running query. Status code: {}.\n {} \n errors: {}" .format(
-                    response.status_code,
-                    gql_query_str,
-                    response.json()['errors']))
-    else:
-        raise SanError(
-            "Error running query. Status code: {}.\n {} \n errors: {}" .format(
-                response.status_code,
-                gql_query_str,
-                response.json()['errors']))
+  if response.status_code == 200:
+    return __handle_success_response__(response, gql_query_str)
+  else:
+    raise SanError(
+      "Error running query. Status code: {}.\n {}".format(
+        response.status_code,
+        gql_query_str))
 
+def __handle_success_response__(response, gql_query_str):
+  if __result_has_gql_errors__(response):
+    raise SanError(
+      "GraphQL error occured running query {} \n errors: {}".format(
+        gql_query_str,
+        response.json()['errors']))
+  elif __exist_not_empty_result(response):
+    return response.json()['data']
+  else:
+    raise SanError(
+      "Error running query. Status code: {}.\n {} \n errors: {}" .format(
+        response.status_code,
+        gql_query_str,
+        response.json()['errors']))
 
-def __errors(response):
-    return 'errors' in response.json().keys()
-
+def __result_has_gql_errors__(response):
+  return 'errors' in response.json().keys()
 
 def __exist_not_empty_result(response):
-    return len(
-        list(
-            filter(
-                lambda x: x is not None,
-                response.json()['data'].values()))) > 0
+  return 'data' in response.json().keys() and len(
+    list(
+      filter(
+        lambda x: x is not None,
+        response.json()['data'].values()))) > 0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="sanpy",
-    version="0.7.4",
+    version="0.7.5",
     author="Santiment",
     author_email="admin@santiment.net",
     description="Package for Santiment API access with python",


### PR DESCRIPTION
Example wrong query:
```python
san.get(
    "daily_active_addresses/santiment",
    from_date="2013-06-01",
    to_date="2013-06-05",
    interval="11asd"
)
```

Old response:
```
Traceback (most recent call last):
  File "<stdin>", line 5, in <module>
  File "/Users/ivan/work/sanpy/san/get.py", line 24, in get
    res = execute_gql(gql_query)
  File "/Users/ivan/work/sanpy/san/graphql.py", line 19, in execute_gql
    if __exist_not_empty_result(response):
  File "/Users/ivan/work/sanpy/san/graphql.py", line 44, in __exist_not_empty_result
    response.json()['data'].values()))) > 0
KeyError: 'data'
```

New response:
```
Traceback (most recent call last):
  File "<stdin>", line 5, in <module>
  File "/Users/ivan/work/sanpy/san/get.py", line 24, in get
    res = execute_gql(gql_query)
  File "/Users/ivan/work/sanpy/san/graphql.py", line 19, in execute_gql
    if __exist_not_empty_result(response):
  File "/Users/ivan/work/sanpy/san/graphql.py", line 31, in __handle_success_response__
    gql_query_str,
san.error.SanError: GraphQL error occured running query {
    query_0: getMetric(metric: "daily_active_addresses"){
        timeseriesData(
            slug: "santiment"
            from: "2013-06-01T00:00:00+00:00"
            to: "2013-06-05T23:59:59+00:00"
            interval: "11asd",
            aggregation: null
        ){
        datetime value
        }
    }
    } 
 errors: [{'locations': [{'column': 13, 'line': 7}], 'message': 'Argument "interval" has invalid value "11asd".'}]```