### PR TITLE
Changing the description of sanpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ san.get(
 Example result:
 
 ```
-                           activeAddresses
+                                     value
 datetime
 2018-06-01 00:00:00+00:00                2
 2018-06-02 00:00:00+00:00                4
@@ -392,7 +392,7 @@ san.get(
 Example result:
 
 ```
-                           transactionVolume
+                                       value
 datetime
 2018-06-01 00:00:00+00:00          46.848943
 2018-06-02 00:00:00+00:00         666.194095

--- a/san/get.py
+++ b/san/get.py
@@ -9,9 +9,20 @@ CUSTOM_QUERIES = {
     'ohlcv': 'get_ohlcv'
 }
 
+DEPRECATED_QUERIES = {
+    'mvrv_ratio': 'mvrv_usd',
+    'nvt_ratio': 'nvt',
+    'realized_value': 'realized_value_usd',
+    'token_circulation': 'circulation_1d',
+    'burn_rate': 'age_destroyed',
+    'token_age_consumed': 'age_destroyed',
+    'token_velocity': 'velocity'
+}
 
 def get(dataset, **kwargs):
     query, slug = parse_dataset(dataset)
+    if query in DEPRECATED_QUERIES:
+        print(f'**NOTICE**\n{query} will be deprecated in version 0.9.0, please use {DEPRECATED_QUERIES[query]} instead')
     if query in CUSTOM_QUERIES:
         return getattr(san.sanbase_graphql, query)(0, slug, **kwargs)
     if query in V2_METRIC_QUERIES:

--- a/san/sanbase_graphql.py
+++ b/san/sanbase_graphql.py
@@ -3,23 +3,12 @@ import san.sanbase_graphql_helper as sgh
 from san.batch import Batch
 from san.error import SanError
 
-def daily_active_addresses(idx, slug, **kwargs):
-    query_str = sgh.create_query_str(
-        'daily_active_addresses', idx, slug, **kwargs)
-
-    return query_str
 
 # to be removed
 
 
 def burn_rate(idx, slug, **kwargs):
     query_str = sgh.create_query_str('burn_rate', idx, slug, **kwargs)
-
-    return query_str
-
-
-def transaction_volume(idx, slug, **kwargs):
-    query_str = sgh.create_query_str('transaction_volume', idx, slug, **kwargs)
 
     return query_str
 

--- a/san/tests/test_sanbase_integration.py
+++ b/san/tests/test_sanbase_integration.py
@@ -443,6 +443,7 @@ def test_available_metrics():
     functions_list = [
         'average_token_age_consumed_in_days',
         'burn_rate',
+        'daily_active_addresses',
         'daily_active_deposits',
         'dev_activity',
         'emerging_trends',
@@ -476,6 +477,7 @@ def test_available_metrics():
         'top_holders_percent_of_total_supply',
         'top_social_gainers_losers',
         'topic_search',
+        'transaction_volume',
         'daily_avg_marketcap_usd',
         'daily_avg_price_usd',
         'daily_closing_marketcap_usd',
@@ -546,5 +548,5 @@ def test_available_metrics():
         'nvt'
         ]
 
-    assert len(san.available_metrics()) >= 1
-    assert san.available_metrics() == functions_list
+    assert functions_list == san.available_metrics()
+    assert len(functions_list) >= 1

--- a/san/tests/test_sanbase_integration.py
+++ b/san/tests/test_sanbase_integration.py
@@ -443,7 +443,6 @@ def test_available_metrics():
     functions_list = [
         'average_token_age_consumed_in_days',
         'burn_rate',
-        'daily_active_addresses',
         'daily_active_deposits',
         'dev_activity',
         'emerging_trends',
@@ -477,7 +476,6 @@ def test_available_metrics():
         'top_holders_percent_of_total_supply',
         'top_social_gainers_losers',
         'topic_search',
-        'transaction_volume',
         'daily_avg_marketcap_usd',
         'daily_avg_price_usd',
         'daily_closing_marketcap_usd',
@@ -548,6 +546,5 @@ def test_available_metrics():
         'nvt'
         ]
 
-    assert available_metrics == san.available_metrics()
-    assert len(available_metrics) >= 1
-    assert available_metrics == functions_list
+    assert len(san.available_metrics()) >= 1
+    assert san.available_metrics() == functions_list

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="sanpy",
-    version="0.7.6",
+    version="0.7.7",
     author="Santiment",
     author_email="admin@santiment.net",
     description="Package for Santiment API access with python",


### PR DESCRIPTION
When you input:

from_date = '2018-01-01'
to_date = '2019-11-01'
asset = 'ethereum'
interval = '1d'

san.get( f'daily_active_addresses/{asset}', from_date=from_date, to_date=to_date, interval=interval )

you get a data frame with a column with the name of 'value' instead of 'daily active addresses'

I've fixed the description in the README and removed the functions, which were for the old API.