### PR TITLE
Updating the list of metrics with min interval of 5 mins

### DIFF
--- a/on-chain-metrics.md
+++ b/on-chain-metrics.md
@@ -103,7 +103,10 @@ List of with metrics with 1 day minimal resolution:
 
 - nvt
 
-List of with metrics with 5 minutes minimal resolution:
+List of metrics with 5 minutes minimal resolution:
 
-- transaction_volume_5min
-- age_destroyed_5min
+- transaction_volume
+- age_destroyed
+- exchange_inflow
+- exchange_outflow
+- exchange_balance

--- a/san/tests/test_sanbase_integration.py
+++ b/san/tests/test_sanbase_integration.py
@@ -537,12 +537,10 @@ def test_available_metrics():
         'realized_value_usd_1d',
         'velocity',
         'transaction_volume',
-        'transaction_volume_5min',
         'exchange_inflow',
         'exchange_outflow',
         'exchange_balance',
         'age_destroyed',
-        'age_destroyed_5min',
         'nvt'
         ]
 

--- a/san/tests/test_sanbase_integration.py
+++ b/san/tests/test_sanbase_integration.py
@@ -443,7 +443,6 @@ def test_available_metrics():
     functions_list = [
         'average_token_age_consumed_in_days',
         'burn_rate',
-        'daily_active_addresses',
         'daily_active_deposits',
         'dev_activity',
         'emerging_trends',
@@ -477,7 +476,6 @@ def test_available_metrics():
         'top_holders_percent_of_total_supply',
         'top_social_gainers_losers',
         'topic_search',
-        'transaction_volume',
         'daily_avg_marketcap_usd',
         'daily_avg_price_usd',
         'daily_closing_marketcap_usd',
@@ -549,4 +547,4 @@ def test_available_metrics():
         ]
 
     assert functions_list == san.available_metrics()
-    assert len(functions_list) >= 1
+    assert len(san.available_metrics()) >= 1

--- a/san/v2_metrics_list.py
+++ b/san/v2_metrics_list.py
@@ -60,12 +60,10 @@ V2_METRIC_QUERIES = [
       "realized_value_usd_1d",
       "velocity",
       "transaction_volume",
-      "transaction_volume_5min",
       "exchange_inflow",
       "exchange_outflow",
       "exchange_balance",
       "age_destroyed",
-      "age_destroyed_5min",
       "nvt"
 
 ]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="sanpy",
-    version="0.7.7",
+    version="0.7.8",
     author="Santiment",
     author_email="admin@santiment.net",
     description="Package for Santiment API access with python",


### PR DESCRIPTION
age_destroyed_5min and transaction_volume_5min are no longer available with the same names. Also, adding to the list of metrics with min interval 5 min new ones.