### PR TITLE
Fix to_date parameter

### DIFF
--- a/san/sanbase_graphql_helper.py
+++ b/san/sanbase_graphql_helper.py
@@ -1,5 +1,6 @@
 import iso8601
 import datetime
+import re
 
 _DEFAULT_INTERVAL = '1d'
 _DEFAULT_SOCIAL_VOLUME_TYPE = 'PROFESSIONAL_TRADERS_CHAT_OVERVIEW'
@@ -273,9 +274,13 @@ def _format_from_date(datetime_obj_or_str):
 def _format_to_date(datetime_obj_or_str):
     if isinstance(datetime_obj_or_str, datetime.datetime):
         datetime_obj_or_str = datetime_obj_or_str.isoformat()
+    else:
+        if _validate_iso8601(datetime_obj_or_str):
+            dt = iso8601.parse_date(datetime_obj_or_str)
+        else:
+            dt = iso8601.parse_date(datetime_obj_or_str) + \
+                datetime.timedelta(hours=23, minutes=59, seconds=59)
 
-    dt = iso8601.parse_date(datetime_obj_or_str) + \
-        datetime.timedelta(hours=23, minutes=59, seconds=59)
     return dt.isoformat()
 
 def _format_all_return_fields(fields):
@@ -287,3 +292,13 @@ def _format_return_fields(fields):
     return list(map(
         lambda el: el[0] + '{{' + ' '.join(el[1]) + '}}' if isinstance(el, tuple) else el
     , fields))
+
+def _validate_iso8601(str_val):
+    regex = r'^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$'
+    match_iso8601 = re.compile(regex).match
+    try:            
+        if match_iso8601( str_val ) is not None:
+            return True
+    except:
+        pass
+    return False

--- a/san/sanbase_graphql_helper.py
+++ b/san/sanbase_graphql_helper.py
@@ -1,6 +1,5 @@
 import iso8601
 import datetime
-import re
 
 _DEFAULT_INTERVAL = '1d'
 _DEFAULT_SOCIAL_VOLUME_TYPE = 'PROFESSIONAL_TRADERS_CHAT_OVERVIEW'
@@ -272,14 +271,17 @@ def _format_from_date(datetime_obj_or_str):
 
 
 def _format_to_date(datetime_obj_or_str):
-    date_format = '%Y-%m-%d'
-    try:            
-        datetime.datetime.strptime(datetime_obj_or_str, date_format)
+    if isinstance(datetime_obj_or_str, datetime.datetime):
+      return datetime_obj_or_str.isoformat()
+    
+    try:
+        # Throw if the string is not date-formated, parse as date otherwise
+        datetime.datetime.strptime(datetime_obj_or_str, '%Y-%m-%d')
         dt = iso8601.parse_date(datetime_obj_or_str) + \
             datetime.timedelta(hours=23, minutes=59, seconds=59)
-    except ValueError:
+    except:
         dt = iso8601.parse_date(datetime_obj_or_str)
-
+    
     return dt.isoformat()
 
 def _format_all_return_fields(fields):

--- a/san/sanbase_graphql_helper.py
+++ b/san/sanbase_graphql_helper.py
@@ -272,14 +272,13 @@ def _format_from_date(datetime_obj_or_str):
 
 
 def _format_to_date(datetime_obj_or_str):
-    if isinstance(datetime_obj_or_str, datetime.datetime):
-        datetime_obj_or_str = datetime_obj_or_str.isoformat()
-    else:
-        if _validate_iso8601(datetime_obj_or_str):
-            dt = iso8601.parse_date(datetime_obj_or_str)
-        else:
-            dt = iso8601.parse_date(datetime_obj_or_str) + \
-                datetime.timedelta(hours=23, minutes=59, seconds=59)
+    date_format = '%Y-%m-%d'
+    try:            
+        datetime.datetime.strptime(datetime_obj_or_str, date_format)
+        dt = iso8601.parse_date(datetime_obj_or_str) + \
+            datetime.timedelta(hours=23, minutes=59, seconds=59)
+    except ValueError:
+        dt = iso8601.parse_date(datetime_obj_or_str)
 
     return dt.isoformat()
 
@@ -292,13 +291,3 @@ def _format_return_fields(fields):
     return list(map(
         lambda el: el[0] + '{{' + ' '.join(el[1]) + '}}' if isinstance(el, tuple) else el
     , fields))
-
-def _validate_iso8601(str_val):
-    regex = r'^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$'
-    match_iso8601 = re.compile(regex).match
-    try:            
-        if match_iso8601( str_val ) is not None:
-            return True
-    except:
-        pass
-    return False

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="sanpy",
-    version="0.7.10",
+    version="0.7.11",
     author="Santiment",
     author_email="admin@santiment.net",
     description="Package for Santiment API access with python",


### PR DESCRIPTION
The following script:
```python
get(
    "transaction_volume/santiment",
    from_date="2018-01-01T00:00:00Z",
    to_date="2018-01-01T01:00:00Z",
    interval="5m"
)
```
Returns 300 records, from 1st to 2nd of January, 2018, which is false.
It should return only records for the first hour of 01.01.2018.
Problem was an implementation detail, which adds an additional 23:59:59 hours to the to_date.