### PR TITLE
fixed bug affecting the functionality of setting a certain bet size

### DIFF
--- a/san/backtest.py
+++ b/san/backtest.py
@@ -34,7 +34,7 @@ class Backtest:
         if trades[-1]:  # include last day sell to make benchmark possible
             self.nr_trades['sell'].append(self.trades.index[i])
 
-        self.performance = ((self.strategy_returns * percent_invested_per_trade) * self.trades + 1).cumprod() - 1
+        self.performance = (self.strategy_returns + 1).cumprod() - 1
         self.benchmark = (returns + 1).cumprod() - 1
 
     def get_sharpe_ratio(self, decimals=2):


### PR DESCRIPTION
Bug fix for the `percent_invested_per_trade` value. `self.strategy_returns` was already multiplied by this value. The same goes for `self.trades`. 

Both should have not affected the research because we use 1 as default for `percent_invested_per_trade` and `self.trades` are typically 0 and 1. So multiplying with these values multiple times has no effect on the result.  