### PR TITLE
Adding a try except block in execute_gql function

### DIFF
--- a/san/graphql.py
+++ b/san/graphql.py
@@ -15,7 +15,7 @@ def execute_gql(gql_query_str):
             json={'query': gql_query_str},
             headers=headers)
     except requests.exceptions.RequestException as e:
-        raise SanError(e)
+        raise SanError('Error running query: ({})'.format(e))
 
     if response.status_code == 200:
         return __handle_success_response__(response, gql_query_str)

--- a/san/graphql.py
+++ b/san/graphql.py
@@ -9,10 +9,13 @@ def execute_gql(gql_query_str):
     if ApiConfig.api_key:
         headers = {'authorization': "Apikey {}".format(ApiConfig.api_key)}
 
-    response = requests.post(
-        SANBASE_GQL_HOST,
-        json={'query': gql_query_str},
-        headers=headers)
+    try:
+        response = requests.post(
+            SANBASE_GQL_HOST,
+            json={'query': gql_query_str},
+            headers=headers)
+    except requests.exceptions.RequestException as e:
+        raise SanError(e)
 
     if response.status_code == 200:
         return __handle_success_response__(response, gql_query_str)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="sanpy",
-    version="0.8.4",
+    version="0.8.5",
     author="Santiment",
     author_email="admin@santiment.net",
     description="Package for Santiment API access with python",


### PR DESCRIPTION
Currently in the execute_gql function there's no try except block, such that if the requests.post method fails for some reason, a proper error is returned:
Before
```bash
Traceback (most recent call last):
  File "example.py", line 2, in <module>
    res = san.available_metrics_for_slug(slug='santiment')
  File "/home/spiderjako/Work/sanpy/san/available_metrics.py", line 22, in available_metrics_for_slug
    return execute_gql(query_str)['projectBySlug']['availableMetrics']
  File "/home/spiderjako/Work/sanpy/san/graphql.py", line 15, in execute_gql
    headers=headers)
  File "/home/spiderjako/.local/lib/python3.6/site-packages/requests/api.py", line 119, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "/home/spiderjako/.local/lib/python3.6/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/spiderjako/.local/lib/python3.6/site-packages/requests/sessions.py", line 530, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/spiderjako/.local/lib/python3.6/site-packages/requests/sessions.py", line 643, in send
    r = adapter.send(request, **kwargs)
  File "/home/spiderjako/.local/lib/python3.6/site-packages/requests/adapters.py", line 516, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='localhost', port=40000): Max retries exceeded with url: /graphql (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f2bc953f940>: Failed to establish a new connection: [Errno 111] Connection refused',))
```

Now
```bash
Traceback (most recent call last):
  File "/home/spiderjako/Work/sanpy/san/graphql.py", line 16, in execute_gql
    headers=headers)
  File "/home/spiderjako/.local/lib/python3.6/site-packages/requests/api.py", line 119, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "/home/spiderjako/.local/lib/python3.6/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/spiderjako/.local/lib/python3.6/site-packages/requests/sessions.py", line 530, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/spiderjako/.local/lib/python3.6/site-packages/requests/sessions.py", line 643, in send
    r = adapter.send(request, **kwargs)
  File "/home/spiderjako/.local/lib/python3.6/site-packages/requests/adapters.py", line 516, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='localhost', port=4000): Max retries exceeded with url: /graphql (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f26a8047940>: Failed to establish a new connection: [Errno 111] Connection refused',))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "example.py", line 2, in <module>
    res = san.available_metrics_for_slug(slug='santiment')
  File "/home/spiderjako/Work/sanpy/san/available_metrics.py", line 22, in available_metrics_for_slug
    return execute_gql(query_str)['projectBySlug']['availableMetrics']
  File "/home/spiderjako/Work/sanpy/san/graphql.py", line 18, in execute_gql
    raise SanError(e)
san.error.SanError: Error running query: (HTTPSConnectionPool(host='localhost', port=40000): Max retries exceeded with url: /graphql (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fda8c949c88>: Failed to establish a new connection: [Errno 111] Connection refused',)))
```