### PR TITLE
Add async batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,14 +242,12 @@ batch.get(
     to_date="2018-06-05",
     interval="1d"
 )
-
 batch.get(
     "transaction_volume/santiment",
     from_date="2018-06-01",
     to_date="2018-06-05",
     interval="1d"
 )
-
 [daa, trx_volume] = batch.execute(max_workers=10)
 ```
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,24 @@ Example result:
 
 ### Batching multiple queries
 
+Multiple queries can be executed in a batch to speed up the performance.
+
+There are two batch classes provided - `Batch` and `AsyncBatch`.
+
+- `Batch` combines all the provided queries in a single GraphQL document and
+executes them in a single HTTP request. This batching technique should be used
+when lightweight queries that don't fetch a lot of data are used. The reason is
+that the [complexity](https://academy.santiment.net/for-developers/#graphql-api-complexity) of each query
+is accumulated and the batch can be rejected.
+- `AsyncBatch` executes all the queries in separate API calls. The benefit of using `AsyncBatch`
+  over looping and executing every API call is that the queries can be executed concurrently.
+  The concurrency is controlled by the `max_workers` optional parameter to the `execute` function.
+  By default the `max_workers` value is 10.
+  
+Note: If you have been using `Batch()` and want to switch to the newer `AsyncBatch()` you only need to
+change the batch initialization. The functions for adding queries and executing the batch, as well as the
+format of the response, are the same.
+
 ```python
 from san import Batch
 
@@ -211,6 +229,28 @@ batch.get(
 )
 
 [daa, trx_volume] = batch.execute()
+```
+
+```python
+from san import AsyncBatch
+
+batch = AsyncBatch()
+
+batch.get(
+    "daily_active_addresses/santiment",
+    from_date="2018-06-01",
+    to_date="2018-06-05",
+    interval="1d"
+)
+
+batch.get(
+    "transaction_volume/santiment",
+    from_date="2018-06-01",
+    to_date="2018-06-05",
+    interval="1d"
+)
+
+[daa, trx_volume] = batch.execute(max_workers=10)
 ```
 
 ### Making a custom graphql query to the API

--- a/san/__init__.py
+++ b/san/__init__.py
@@ -3,6 +3,7 @@ from .metadata import metadata
 from .metric_complexity import metric_complexity
 from .available_metrics import available_metrics, available_metrics_for_slug, available_metric_for_slug_since
 from .batch import Batch
+from .async_batch import AsyncBatch
 from .api_config import ApiConfig
 import pkg_resources
 import requests

--- a/san/async_batch.py
+++ b/san/async_batch.py
@@ -1,0 +1,56 @@
+import san.sanbase_graphql
+import asyncio
+from concurrent.futures import ProcessPoolExecutor
+
+from san.sanbase_graphql_helper import QUERY_MAPPING
+from san.query import get_gql_query
+from san.graphql import execute_gql
+from san.transform import transform_query_result
+from san.error import SanError
+
+
+def task(request):
+    [idx, [identifier, kwargs]] = request
+    
+    metric, _separator, slug = identifier.partition("/")
+
+    if metric in QUERY_MAPPING:
+        gql_string_query = get_gql_query(idx, identifier, **kwargs)
+    elif slug != '':
+        gql_string_query = san.sanbase_graphql.get_metric(idx, metric, slug, **kwargs)
+    else:
+        raise SanError('Invalid metric!')
+                
+    response = execute_gql("{" + gql_string_query + "}")
+    return response
+
+class AsyncBatch:
+    def __init__(self):
+        self.queries = []
+
+    def get(self, dataset, **kwargs):
+        self.queries.append([dataset, kwargs])
+
+    def execute(self, max_workers=10):
+        graphql_result = {}
+
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+            for response in executor.map(task, enumerate(self.queries)):
+                # response is in the format {'query_0': '<value>'}
+                [(key, value)] = list(response.items())
+                
+                graphql_result[key] = value
+            
+            result = self.__transform_batch_result(graphql_result)
+            return result
+
+
+    def __transform_batch_result(self, graphql_result):
+        result = []
+        idxs = sorted([int(k.split('_')[1]) for k in graphql_result.keys()])
+
+        for idx in idxs:
+            query = self.queries[idx][0].split("/")[0]
+            df = transform_query_result(idx, query, graphql_result)
+            result.append(df)
+        return result

--- a/san/async_batch.py
+++ b/san/async_batch.py
@@ -1,6 +1,6 @@
 import san.sanbase_graphql
 import asyncio
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 
 from san.sanbase_graphql_helper import QUERY_MAPPING
 from san.query import get_gql_query
@@ -34,7 +34,7 @@ class AsyncBatch:
     def execute(self, max_workers=10):
         graphql_result = {}
 
-        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
             for response in executor.map(task, enumerate(self.queries)):
                 # response is in the format {'query_0': '<value>'}
                 [(key, value)] = list(response.items())

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='sanpy',
-    version='0.10.1',
+    version='0.10.2',
     author='Santiment',
     author_email='admin@santiment.net',
     description='Package for Santiment API access with python',


### PR DESCRIPTION
Multiple queries can be executed in a batch to speed up the performance.

There are two batch classes provided - `Batch` and `AsyncBatch`.

- `Batch` combines all the provided queries in a single GraphQL document and
executes them in a single HTTP request. This batching technique should be used
when lightweight queries that don't fetch a lot of data are used. The reason is
that the [complexity](https://academy.santiment.net/for-developers/#graphql-api-complexity) of each query
is accumulated and the batch can be rejected.
- `AsyncBatch` executes all the queries in separate API calls. The benefit of using `AsyncBatch`
  over looping and executing every API call is that the queries can be executed concurrently.
  The concurrency is controlled by the `max_workers` optional parameter to the `execute` function.
  By default the `max_workers` value is 10.
  
Note: If you have been using `Batch()` and want to switch to the newer `AsyncBatch()` you only need to
change the batch initialization. The functions for adding queries and executing the batch, as well as the
format of the response, are the same.


```python
from san import AsyncBatch

batch = AsyncBatch()

batch.get(
    "daily_active_addresses/santiment",
    from_date="2018-06-01",
    to_date="2018-06-05",
    interval="1d"
)
batch.get(
    "transaction_volume/santiment",
    from_date="2018-06-01",
    to_date="2018-06-05",
    interval="1d"
)
[daa, trx_volume] = batch.execute(max_workers=10)
```