### PR TITLE
Fix san.available_functions()

### DIFF
--- a/san/available_metrics.py
+++ b/san/available_metrics.py
@@ -5,7 +5,7 @@ from san.graphql import execute_gql
 def available_metrics():
     sanbase_graphql_functions = inspect.getmembers(san.sanbase_graphql, inspect.isfunction)
     all_functions =  list(map(lambda x: x[0], sanbase_graphql_functions)) + execute_gql('{query: getAvailableMetrics}')['query']
-    all_functions.remove('get_metric')
+    all_functions = list(filter(lambda x: not (str.startswith(x, "get_metric" or str.startswith(x, "_"))), all_functions)) 
     return all_functions
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='sanpy',
-    version='0.11.1',
+    version='0.11.2',
     author='Santiment',
     author_email='admin@santiment.net',
     description='Package for Santiment API access with python',


### PR DESCRIPTION
Properly exclude some functions from the list of available_metrics