### PR TITLE
Add execute_sql function

### DIFF
--- a/san/__init__.py
+++ b/san/__init__.py
@@ -13,6 +13,7 @@ from .batch import Batch
 from .env_vars import SANPY_APIKEY
 from .get import get
 from .get_many import get_many
+from .execute_sql import execute_sql
 from .metadata import metadata
 from .metric_complexity import metric_complexity
 from .utility import (api_calls_made, api_calls_remaining,

--- a/san/execute_sql.py
+++ b/san/execute_sql.py
@@ -1,0 +1,85 @@
+import san.sanbase_graphql
+import pandas as pd
+from san.graphql import execute_gql, get_response_headers
+from san.query import get_gql_query, parse_dataset
+from san.transform import transform_timeseries_data_query_result
+from san.error import SanError
+import json
+
+def execute_sql(**kwargs):
+    """
+    Execute an arbitrary SQL against Santiment's Clickhouse Database
+
+    Example:
+        san.execute_sql(query=\"""
+        SELECT
+            get_metric_name(metric_id) AS metric,
+            get_asset_name(asset_id) AS asset,
+            dt,
+            value
+        FROM daily_metrics_v2
+        WHERE
+            asset_id = get_asset_id({{slug}}) AND
+            metric_id = get_metric_id({{metric}}) AND
+            dt >= now() - INTERVAL {{last_n_days}} DAY
+        ORDER BY dt ASC
+        \""",
+        parameters={'slug': 'bitcoin', 'metric': 'daily_active_addresses', 'last_n_days': 7},
+        set_index="dt")
+    """
+    if 'query' in kwargs:
+        query = kwargs.pop('query')
+    else:
+        raise SanError("The 'query' argument is required when calling 'execute_sql'")
+
+    parameters = kwargs.pop('parameters', {})
+
+    result = __execute_sql(query, parameters, **kwargs)
+    transformed_result = result
+
+    return transformed_result
+
+def __execute_sql(query, parameters, **kwargs):
+    idx = kwargs.pop('idx', 0)
+    # Export the python dictionary parameters to a JSON string
+    # where each of the quotes " is replaced with \", so when interpolated
+    # in the GraphQL parameters field it is properly escaped
+    parameters = json.dumps(parameters).replace('"', '\\"')
+
+    # Replace the new lines with explicit new lines \\n. Othewise the
+    # GraphQL query is malformed as it does not support multiline strings
+    query = query.replace('\n', '\\n')
+
+    gql_query = f"""{{
+        query_{idx}:  computeRawClickhouseQuery(
+            query: "{query}"
+            parameters: "{parameters}"
+        ){{
+            columns
+            columnTypes
+            rows
+        }}
+    }}"""
+
+    res = execute_gql(gql_query)
+    res = __transform_sql_result(res, idx, **kwargs)
+
+    return res
+
+def __transform_sql_result(response, idx, **kwargs):
+    result = response[f'query_{idx}']
+    result = pd.DataFrame(result['rows'], columns=result['columns'])
+
+    set_index = kwargs.get('set_index')
+
+    if set_index == None:
+        pass
+    elif set_index not in result.columns:
+        raise SanError(f"""
+        Index provided via \'set_index\' to \'execute_sql\' is not a column in the result.
+        Got {set_index} but expected one of {result.columns}
+        """)
+    else:
+        result = result.set_index(set_index)
+
+    return result

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='sanpy',
-    version='0.11.5',
+    version='0.11.6',
     author='Santiment',
     author_email='admin@santiment.net',
     description='Package for Santiment API access with python',


### PR DESCRIPTION
Add helper functions to easily execute SQL:
```python
san.execute_sql(query="""
  SELECT
    get_metric_name(metric_id) AS metric,
    get_asset_name(asset_id) AS asset,
    dt,
    argMax(value, computed_at)
  FROM daily_metrics_v2
  WHERE
    asset_id = get_asset_id({{slug}}) AND
    metric_id = get_metric_id({{metric}}) AND
    dt >= now() - INTERVAL {{last_n_days}} DAY
  GROUP BY dt, metric_id, asset_id
  ORDER BY dt ASC
""",
parameters={'slug': 'bitcoin', 'metric': 'daily_active_addresses', 'last_n_days': 7},
set_index="dt")
```
```
dt                                         metric   asset  value                     
2023-03-22T00:00:00Z  daily_active_addresses  bitcoin                    941446.0
2023-03-23T00:00:00Z  daily_active_addresses  bitcoin                    913215.0
2023-03-24T00:00:00Z  daily_active_addresses  bitcoin                    884271.0
2023-03-25T00:00:00Z  daily_active_addresses  bitcoin                    906851.0
2023-03-26T00:00:00Z  daily_active_addresses  bitcoin                    835596.0
2023-03-27T00:00:00Z  daily_active_addresses  bitcoin                   1052637.0
2023-03-28T00:00:00Z  daily_active_addresses  bitcoin                    311566.0
```
