### PR TITLE
Specify sanpy version in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ More documentation regarding the API and definitions of metrics can be found on 
 To install the latest [sanpy from PyPI](https://pypi.org/project/sanpy/):
 
 ```bash
-pip install sanpy
+# Install the latest version
+pip install sanpy==0.12.3
 ```
 
 ## Upgrade to latest version


### PR DESCRIPTION
Updated installation instructions for sanpy to specify version 0.12.3.